### PR TITLE
feat: Add multilingual support and update SEO metadata

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a **Crexative** website built with **Astro** - a modern landing page for a creative design agency. The project is configured to deploy to https://crexative.com and uses pnpm as the package manager.
+This is a **Crexative** website built with **Astro** - a modern landing page for a creative design agency operating across Colombia. The project is configured to deploy to https://crexative.com and uses pnpm as the package manager.
 
 ## Development Commands
 
@@ -15,38 +15,65 @@ All commands should be run from the project root using pnpm:
 - `pnpm preview` - Preview production build locally
 - `pnpm astro check` - Run Astro's built-in type checking and diagnostics
 
+### Performance & SEO Commands
+- `pnpm run build:analyze` - Build and analyze bundle size
+- `pnpm run lighthouse` - Run Lighthouse audit on localhost:4321
+- `pnpm run lighthouse:ci` - Run Lighthouse CI
+- `pnpm run seo-check` - Quick SEO validation report
+- `pnpm run performance` - Full performance audit (build → preview → lighthouse)
+- `pnpm run validate-html` - Validate HTML structure
+- `pnpm run check-links` - Check for broken links
+
 ## Architecture
 
 ### Component Structure
 The site follows a standard Astro component-based architecture:
 
-- **Layout**: `src/layouts/Layout.astro` - Base layout with global styles, theme system, and HTML structure
+- **Layout**: `src/layouts/Layout.astro` - Base layout with comprehensive SEO, theme system, and global styles
 - **Pages**: `src/pages/index.astro` - Single page application composing all components
-- **Components**: `src/components/` - Reusable UI components for different sections (Hero, Services, About, Stats, Contact, Footer, Navbar)
+- **Components**: `src/components/` - Reusable UI components for different sections
+- **SEO Pages**: `src/pages/robots.txt.ts` and `src/pages/sitemap.xml.ts` - Programmatic SEO files
 
-### Styling Approach
-- Uses scoped CSS within individual `.astro` components
-- Global styles and CSS variables defined in `Layout.astro`
-- Implements a light/dark theme system with CSS custom properties
-- Uses Poppins Google Font
-- Responsive design with mobile-first approach
+### Component Composition
+The homepage (`src/pages/index.astro`) follows this structure:
+1. Layout wrapper with SEO metadata
+2. Navbar (brand navigation)
+3. Hero (main banner)
+4. Services (service offerings)
+5. About (company information)
+6. Contact (contact form)
+7. Footer (footer content)
+8. StickyCallToAction (persistent CTA)
 
-### Key Features
-- **Theme System**: Light/dark mode toggle with localStorage persistence
-- **Brand Identity**: "CREXATIVE" brand name with primary color (#00e1c7)
-- **Landing Page Sections**: Hero, Services, About, Stats, Contact
-- **Responsive Design**: Mobile-optimized layouts
+### Styling & Theme System
+- **Global Styles**: Comprehensive CSS custom properties in `src/layouts/Layout.astro`
+- **Typography**: Inter + Playfair Display font combination with performance optimizations
+- **Theme System**: Light/dark mode with localStorage persistence and custom event system
+- **Color Palette**: Primary (#00e1c7), Secondary (#6366f1), with full gradient system
+- **Responsive Design**: Mobile-first approach with clamp() functions for fluid typography
 
-### File Organization
-- `src/components/` - Individual section components
-- `src/layouts/` - Base layout template
-- `src/pages/` - Page routes (single page app)
-- `src/assets/` - Static assets (SVGs)
-- `public/` - Public assets (images, favicon, CNAME)
+### SEO & Performance Architecture
+- **Structured Data**: JSON-LD schema for organization information
+- **Meta Tags**: Comprehensive OpenGraph, Twitter Card, and geo-location metadata
+- **Resource Optimization**: Preload critical assets, DNS prefetch, font display optimization
+- **Performance**: Optimized Vite build configuration with asset chunking
 
 ## Configuration
 
-- **Site URL**: https://crexative.com (configured in astro.config.mjs)
-- **TypeScript**: Strict mode enabled
+### Core Configuration
+- **Site URL**: https://crexative.com (astro.config.mjs)
+- **TypeScript**: Strict mode enabled (tsconfig.json extends astro/tsconfigs/strict)
 - **Package Manager**: pnpm (lockfile present)
-- **Deployment**: Configured with GitHub Actions (astro.yml) and CNAME file
+- **Build Output**: Static site generation with optimized asset handling
+
+### Deployment Configuration
+- **GitHub Actions**: `.github/workflows/astro.yml` - Auto-deploy to GitHub Pages on main branch
+- **Domain**: Custom domain via `public/CNAME` file
+- **Headers**: Performance headers in `public/_headers`
+- **Redirects**: Netlify-style redirects in `public/_redirects`
+
+### Build Optimization
+- **Asset Strategy**: Organized by type (images/, css/, assets/)
+- **Compression**: HTML compression enabled
+- **Minification**: ESBuild minification with CSS code splitting
+- **Source Maps**: Disabled for production builds

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-This is a **Crexative** website built with **Astro** - a modern landing page for a creative design agency operating across Colombia. The project is configured to deploy to https://crexative.com and uses pnpm as the package manager.
+This is a **Crexative** website built with **Astro** - a modern landing page for a creative design agency operating across Colombia. The project is configured to deploy to https://crexative.com and uses pnpm as the package manager. The website supports both English and Spanish languages with complete internationalization (i18n) implementation.
 
 ## Development Commands
 
@@ -77,3 +77,30 @@ The homepage (`src/pages/index.astro`) follows this structure:
 - **Compression**: HTML compression enabled
 - **Minification**: ESBuild minification with CSS code splitting
 - **Source Maps**: Disabled for production builds
+
+## Internationalization (i18n)
+
+### Language Support
+- **Spanish**: Default language at `/` (es)
+- **English**: Available at `/en/`
+- **Structure**: Clean separation with locale files in `src/i18n/locales/`
+
+### Translation System
+- **Configuration**: `src/i18n/index.ts` - Main i18n utilities and type definitions
+- **English Translations**: `src/i18n/locales/en.ts`
+- **Spanish Translations**: `src/i18n/locales/es.ts`
+- **Component Integration**: All components accept `lang` prop and use `useTranslations()` hook
+- **Language Switcher**: Dropdown component with localStorage persistence and URL routing
+
+### Key Features
+- **Automatic Fallback**: Falls back to Spanish (default) if translation missing
+- **Type Safety**: Complete TypeScript support with `TranslationKey` type
+- **SEO Optimization**: Language-specific meta tags, structured data, and OpenGraph locale
+- **URL Structure**: Clean URLs with language prefix (`/en/`) for English, Spanish at root
+- **Browser Storage**: Language preference saved in localStorage
+
+### Component Architecture
+All components are internationalized and accept a `lang` prop:
+- Hero, Services, About, Contact, Footer, Navbar, StickyCallToAction
+- Language-aware internal linking and content rendering
+- Structured translation keys for maintainability

--- a/src/components/About.astro
+++ b/src/components/About.astro
@@ -1,18 +1,26 @@
 ---
+import { useTranslations } from '../i18n';
+
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang as 'en' | 'es');
 ---
 
 <section id="about" class="about" itemscope itemtype="https://schema.org/Organization">
   <div class="container">
     <div class="section-header">
-      <p class="subtitle">ABOUT US</p>
-      <h2>WHO ARE <span class="primary-color">WE</span>?</h2>
+      <p class="subtitle">{t('about.title')}</p>
+      <h2>{t('about.subtitle')}</h2>
     </div>
     
     <div class="about-content">
       <div class="about-image">
         <img 
           src="/images/about.png" 
-          alt="CREXATIVE software development team - Expert developers and engineers working on innovative projects in Medellín, Colombia"
+          alt={lang === 'es' ? 'Equipo de desarrollo de software CREXATIVE - Desarrolladores e ingenieros expertos trabajando en proyectos innovadores en Colombia' : 'CREXATIVE software development team - Expert developers and engineers working on innovative projects in Colombia'}
           width="500"
           height="400"
           loading="lazy"
@@ -22,29 +30,29 @@
       
       <div class="about-text">
         <p itemprop="description">
-          We are a passionate team of creative professionals dedicated to bringing your vision to life. With years of experience in digital design and development, we specialize in creating exceptional user experiences that drive results. Our collaborative approach ensures that every project reflects your unique brand identity while meeting the highest standards of quality and innovation.
+          {t('about.description')}
         </p>
         
         <div class="company-values">
           <div class="value-item">
-            <span class="value-icon">🎯</span>
+            <span class="value-icon">💡</span>
             <div class="value-content">
-              <h4>Quality First</h4>
-              <p>We prioritize quality over quantity in every project</p>
+              <h4>{t('about.values.innovation')}</h4>
+              <p>{t('about.values.innovationDesc')}</p>
             </div>
           </div>
           <div class="value-item">
-            <span class="value-icon">⚡</span>
+            <span class="value-icon">⭐</span>
             <div class="value-content">
-              <h4>Fast Delivery</h4>
-              <p>Quick turnaround times without compromising quality</p>
+              <h4>{t('about.values.quality')}</h4>
+              <p>{t('about.values.qualityDesc')}</p>
             </div>
           </div>
           <div class="value-item">
-            <span class="value-icon">💬</span>
+            <span class="value-icon">🤝</span>
             <div class="value-content">
-              <h4>Clear Communication</h4>
-              <p>Regular updates and transparent project progress</p>
+              <h4>{t('about.values.partnership')}</h4>
+              <p>{t('about.values.partnershipDesc')}</p>
             </div>
           </div>
         </div>
@@ -57,8 +65,8 @@
               </svg>
             </div>
             <div class="feature-text">
-              <h3>Clean Code</h3>
-              <p>We write maintainable, scalable code that follows industry best practices and ensures long-term project success.</p>
+              <h3>{t('misc.cleanCode')}</h3>
+              <p>{t('misc.cleanCodeDesc')}</p>
             </div>
           </article>
           
@@ -71,8 +79,8 @@
               </svg>
             </div>
             <div class="feature-text">
-              <h3>Modern Design</h3>
-              <p>Our designs blend contemporary aesthetics with functional usability, creating experiences that are both beautiful and effective.</p>
+              <h3>{t('misc.modernDesign')}</h3>
+              <p>{t('misc.modernDesignDesc')}</p>
             </div>
           </article>
 
@@ -85,15 +93,14 @@
               </svg>
             </div>
             <div class="feature-text">
-              <h3>Scalable Architecture</h3>
-              <p>We design and implement robust, scalable architectures that grow with your business, ensuring optimal performance and reliability at any scale.</p>
+              <h3>{t('misc.scalableArchitecture')}</h3>
+              <p>{t('misc.scalableArchitectureDesc')}</p>
             </div>
           </article>
         </div>
       </div>
     </div>
   </div>
-</section>
 </section>
 
 <style>

--- a/src/components/Contact.astro
+++ b/src/components/Contact.astro
@@ -1,26 +1,31 @@
 ---
+import { useTranslations } from '../i18n';
+
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang as 'en' | 'es');
+
 const contactSchema = {
-  "@context": "https://schema.org",
-  "@type": "ContactPage",
-  "mainEntity": {
-    "@type": "Organization",
-    "name": "CREXATIVE",
-    "url": "https://crexative.com",
-    "contactPoint": {
-      "@type": "ContactPoint",
-      "telephone": "+57-300-123-4567",
-      "email": "hello@crexative.com",
-      "contactType": "Customer Service",
-      "areaServed": "CO",
-      "availableLanguage": ["Spanish", "English"]
+  '@context': 'https://schema.org',
+  '@type': 'ContactPage',
+  mainEntity: {
+    '@type': 'Organization',
+    name: 'CREXATIVE',
+    url: 'https://crexative.com',
+    contactPoint: {
+      '@type': 'ContactPoint',
+      telephone: '+57-300-123-4567',
+      email: 'hello@crexative.com',
+      contactType: 'Customer Service',
+      areaServed: 'CO',
+      availableLanguage: ['Spanish', 'English']
     },
-    "address": {
-      "@type": "PostalAddress",
-      "streetAddress": "Calle 10 #43-15, El Poblado",
-      "addressLocality": "Medellín",
-      "addressRegion": "Antioquia",
-      "postalCode": "050021",
-      "addressCountry": "CO"
+    address: {
+      '@type': 'PostalAddress',
+      addressCountry: 'CO'
     }
   }
 };
@@ -29,17 +34,17 @@ const contactSchema = {
 <section id="contact" class="contact" itemscope itemtype="https://schema.org/ContactPage">
   <div class="container">
     <div class="section-header">
-      <p class="subtitle">CONTACT US</p>
-      <h2>LET'S WORK <span class="primary-color">TOGETHER</span></h2>
+      <p class="subtitle">{t('contact.title')}</p>
+      <h2>{t('contact.subtitle')}</h2>
       <p class="section-description">
-        Ready to start your next project? Get in touch with our global team of creative professionals for a free consultation.
+        {t('contact.description')}
       </p>
     </div>
     
     <div class="contact-content">
       <div class="contact-info" itemprop="mainEntity" itemscope itemtype="https://schema.org/Organization">
-        <h3>Ready to start your next project?</h3>
-        <p>We're excited to hear about your ideas and help bring them to life. Our global team of creative professionals is ready to collaborate with you remotely, delivering exceptional results regardless of your location.</p>
+        <h3>{t('contact.subtitle')}</h3>
+        <p>{t('contact.description')}</p>
         
         <div class="contact-details">
           <div class="contact-item" itemprop="contactPoint" itemscope itemtype="https://schema.org/ContactPoint">
@@ -50,9 +55,9 @@ const contactSchema = {
               </svg>
             </div>
             <div>
-              <h4>Email</h4>
-              <p><a href="mailto:hello@crexative.com" itemprop="email">hello@crexative.com</a></p>
-              <span class="contact-note">Response within 24 hours</span>
+              <h4>{t('contact.info.email')}</h4>
+              <p><a href={`mailto:${t('contact.details.email')}`} itemprop="email">{t('contact.details.email')}</a></p>
+              <span class="contact-note">{t('misc.responseTime')}</span>
             </div>
           </div>
           
@@ -63,9 +68,9 @@ const contactSchema = {
               </svg>
             </div>
             <div>
-              <h4>Phone</h4>
-              <p>Available via video call</p>
-              <span class="contact-note">Schedule online consultation</span>
+              <h4>{t('contact.info.phone')}</h4>
+              <p>{t('contact.details.phone')}</p>
+              <span class="contact-note">{t('misc.scheduleConsultation')}</span>
             </div>
           </div>
           
@@ -77,35 +82,35 @@ const contactSchema = {
               </svg>
             </div>
             <div>
-              <h4>Global Service</h4>
-              <p>Remote collaboration worldwide</p>
-              <span class="contact-note">Working with clients globally</span>
+              <h4>{t('contact.info.address')}</h4>
+              <p>{t('contact.details.address')}</p>
+              <span class="contact-note">{t('misc.workingGlobally')}</span>
             </div>
           </div>
         </div>
 
         <div class="business-hours">
-          <h4>Business Hours</h4>
+          <h4>{t('contact.info.hours')}</h4>
           <div class="hours-list">
             <div class="hours-item">
-              <span>Monday - Friday:</span>
-              <span>9:00 AM - 6:00 PM COT</span>
+              <span>{t('misc.mondayFriday')}</span>
+              <span>{t('contact.details.hours')}</span>
             </div>
             <div class="hours-item">
-              <span>Saturday:</span>
-              <span>10:00 AM - 2:00 PM COT</span>
+              <span>{t('misc.saturday')}</span>
+              <span>{t('misc.saturdayHours')}</span>
             </div>
             <div class="hours-item">
-              <span>Sunday:</span>
-              <span>Closed</span>
+              <span>{t('misc.sunday')}</span>
+              <span>{t('misc.closed')}</span>
             </div>
           </div>
         </div>
       </div>
       
       <div class="contact-form">
-        <h3>Get Your Free Quote</h3>
-        <p>Tell us about your project and we'll provide a detailed proposal within 48 hours.</p>
+        <h3>{t('misc.getQuote')}</h3>
+        <p>{t('misc.quoteDescription')}</p>
         <form name="contact-form" method="POST" data-netlify="true" netlify-honeypot="bot-field">
           <input type="hidden" name="form-name" value="contact-form" />
           <div class="form-group" style="display: none;">
@@ -115,54 +120,54 @@ const contactSchema = {
           
           <div class="form-row">
             <div class="form-group">
-              <label for="name">Full Name *</label>
-              <input type="text" id="name" name="name" required aria-describedby="name-error">
+              <label for="name">{t('contact.form.name')} *</label>
+              <input type="text" id="name" name="name" required aria-describedby="name-error" placeholder={t('contact.form.namePlaceholder')}>
             </div>
             
             <div class="form-group">
-              <label for="email">Email Address *</label>
-              <input type="email" id="email" name="email" required aria-describedby="email-error">
+              <label for="email">{t('contact.form.email')} *</label>
+              <input type="email" id="email" name="email" required aria-describedby="email-error" placeholder={t('contact.form.emailPlaceholder')}>
             </div>
           </div>
           
           <div class="form-row">
             <div class="form-group">
-              <label for="company">Company Name</label>
-              <input type="text" id="company" name="company">
+              <label for="company">{t('contact.form.company')}</label>
+              <input type="text" id="company" name="company" placeholder={t('contact.form.companyPlaceholder')}>
             </div>
             
             <div class="form-group">
-              <label for="budget">Project Budget</label>
+              <label for="budget">{t('misc.projectBudget')}</label>
               <select id="budget" name="budget">
-                <option value="">Select budget range</option>
-                <option value="under-5k">Under $5,000</option>
+                <option value="">{t('misc.selectBudget')}</option>
+                <option value="under-5k">{t('misc.under5k')}</option>
                 <option value="5k-15k">$5,000 - $15,000</option>
                 <option value="15k-50k">$15,000 - $50,000</option>
-                <option value="50k-plus">$50,000+</option>
+                <option value="50k-plus">{t('misc.over50k')}</option>
               </select>
             </div>
           </div>
           
           <div class="form-group">
-            <label for="service">Service Needed</label>
+            <label for="service">{t('contact.form.service')}</label>
             <select id="service" name="service">
-              <option value="">Select a service</option>
-              <option value="web-development">Web Application Development</option>
-              <option value="mobile-development">Mobile App Development</option>
-              <option value="ui-ux-design">UI/UX Design & Prototyping</option>
-              <option value="ecommerce">E-commerce Solutions</option>
-              <option value="consulting">Technical Consulting</option>
-              <option value="other">Other</option>
+              <option value="">{t('contact.form.servicePlaceholder')}</option>
+              <option value="web-development">{t('services.web.title')}</option>
+              <option value="mobile-development">{t('services.mobile.title')}</option>
+              <option value="ui-ux-design">{t('services.uiux.title')}</option>
+              <option value="ecommerce">{t('services.ecommerce.title')}</option>
+              <option value="consulting">{t('services.consulting.title')}</option>
+              <option value="other">{t('misc.other')}</option>
             </select>
           </div>
           
           <div class="form-group">
-            <label for="message">Project Description *</label>
-            <textarea id="message" name="message" rows="6" required aria-describedby="message-error" placeholder="Tell us about your project goals, timeline, and any specific requirements..."></textarea>
+            <label for="message">{t('contact.form.message')} *</label>
+            <textarea id="message" name="message" rows="6" required aria-describedby="message-error" placeholder={t('contact.form.messagePlaceholder')}></textarea>
           </div>
           
           <button type="submit" class="submit-btn">
-            <span>Get Free Quote</span>
+            <span>{t('contact.form.submit')}</span>
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
               <line x1="22" y1="2" x2="11" y2="13"></line>
               <polygon points="22,2 15,22 11,13 2,9 22,2"></polygon>
@@ -174,7 +179,7 @@ const contactSchema = {
   </div>
   
   <!-- Structured Data -->
-  <script type="application/ld+json" set:html={JSON.stringify(contactSchema)} />
+  <script type="application/ld+json" set:html={JSON.stringify(contactSchema)} is:inline />
 </section>
 
 <style>
@@ -392,6 +397,13 @@ const contactSchema = {
     color: var(--primary-color);
     transform: translateY(-2px);
     box-shadow: 0 10px 25px rgba(0, 225, 199, 0.3);
+  }
+
+  /* Dark mode specific styles for submit button */
+  [data-theme="dark"] .submit-btn:hover {
+    background-color: rgba(0, 225, 199, 0.1) !important;
+    color: var(--primary-color) !important;
+    border-color: var(--primary-color) !important;
   }
 
   .submit-btn svg {

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,26 +1,96 @@
 ---
+import { useTranslations } from '../i18n';
+
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang as 'en' | 'es');
 ---
 
 <footer class="footer">
   <div class="container">
     <div class="footer-content">
-      <div class="footer-logo">
-        <a href="/">CREXATIVE</a>
-        <p>DESIGN BY <span class="primary-color">CREXATIVE</span></p>
+      <div class="footer-brand">
+        <div class="footer-logo">
+          <a href={lang === 'en' ? '/en' : '/'}>CREXATIVE</a>
+          <p>{t('footer.description')}</p>
+        </div>
       </div>
-      <div class="footer-social">
-        <a href="#" class="social-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"></path>
-          </svg>
-        </a>
-        <a href="#" class="social-icon">
-          <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
-            <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path>
-            <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
-          </svg>
-        </a>
+      
+      <div class="footer-links">
+        <div class="footer-section">
+          <h4>{t('footer.sections.company')}</h4>
+          <ul>
+            <li><a href={lang === 'en' ? '/en' : '/'}>{t('footer.links.home')}</a></li>
+            <li><a href="#about">{t('footer.links.about')}</a></li>
+            <li><a href="#services">{t('footer.links.services')}</a></li>
+            <li><a href="#contact">{t('footer.links.contact')}</a></li>
+          </ul>
+        </div>
+        
+        <div class="footer-section">
+          <h4>{t('footer.sections.services')}</h4>
+          <ul>
+            <li><a href="#services">{t('footer.servicesList.web')}</a></li>
+            <li><a href="#services">{t('footer.servicesList.mobile')}</a></li>
+            <li><a href="#services">{t('footer.servicesList.uiux')}</a></li>
+            <li><a href="#services">{t('footer.servicesList.ecommerce')}</a></li>
+          </ul>
+        </div>
+        
+        <div class="footer-section">
+          <h4>{t('footer.sections.contact')}</h4>
+          <ul>
+            <li><a href={`mailto:${t('contact.details.email')}`}>{t('contact.details.email')}</a></li>
+            <li><span>{t('contact.details.phone')}</span></li>
+            <li><span>{t('contact.details.address')}</span></li>
+          </ul>
+        </div>
+        
+        <div class="footer-section">
+          <h4>{t('footer.sections.follow')}</h4>
+          <div class="footer-social">
+            <a href={t('social.linkedin')} class="social-icon" aria-label={t('footer.social.linkedin')} target="_blank" rel="noopener noreferrer">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path>
+                <rect x="2" y="9" width="4" height="12"></rect>
+                <circle cx="4" cy="4" r="2"></circle>
+              </svg>
+            </a>
+            <a href={t('social.twitter')} class="social-icon" aria-label={t('footer.social.twitter')} target="_blank" rel="noopener noreferrer">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z"></path>
+              </svg>
+            </a>
+            <a href={t('social.facebook')} class="social-icon" aria-label={t('footer.social.facebook')} target="_blank" rel="noopener noreferrer">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z"></path>
+              </svg>
+            </a>
+            <a href={t('social.instagram')} class="social-icon" aria-label={t('footer.social.instagram')} target="_blank" rel="noopener noreferrer">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="2" y="2" width="20" height="20" rx="5" ry="5"></rect>
+                <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z"></path>
+                <line x1="17.5" y1="6.5" x2="17.51" y2="6.5"></line>
+              </svg>
+            </a>
+            <a href={t('social.youtube')} class="social-icon" aria-label="YouTube" target="_blank" rel="noopener noreferrer">
+              <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <path d="M22.54 6.42a2.78 2.78 0 0 0-1.94-2C18.88 4 12 4 12 4s-6.88 0-8.6.46a2.78 2.78 0 0 0-1.94 2A29 29 0 0 0 1 11.75a29 29 0 0 0 .46 5.33A2.78 2.78 0 0 0 3.4 19c1.72.46 8.6.46 8.6.46s6.88 0 8.6-.46a2.78 2.78 0 0 0 1.94-2 29 29 0 0 0 .46-5.25 29 29 0 0 0-.46-5.33z"></path>
+                <polygon points="9.75,15.02 15.5,11.75 9.75,8.48"></polygon>
+              </svg>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+    
+    <div class="footer-bottom">
+      <div class="footer-copyright">
+        <p>&copy; 2024 CREXATIVE. {t('footer.copyright')}</p>
+        <p class="footer-made">{t('footer.madeWith')}</p>
       </div>
     </div>
   </div>
@@ -28,54 +98,193 @@
 
 <style>
   .footer {
-    padding: 30px 0;
+    padding: 60px 0 30px;
     background-color: var(--footer-bg);
     border-top: 1px solid var(--border-color);
+    color: white;
   }
   
   .footer-content {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 50px;
+    margin-bottom: 40px;
+  }
+  
+  .footer-brand {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
   }
   
   .footer-logo a {
-    font-size: 24px;
+    font-size: 28px;
     font-weight: 700;
     color: var(--primary-color);
     letter-spacing: 1px;
-    margin-bottom: 5px;
+    margin-bottom: 15px;
     display: block;
   }
   
   .footer-logo p {
-    font-size: 12px;
-    color: var(--text-gray);
+    font-size: 14px;
+    color: #e2e8f0;
     margin: 0;
+    line-height: 1.6;
+    max-width: 300px;
+  }
+  
+  .footer-links {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 30px;
+  }
+  
+  .footer-section h4 {
+    font-size: 16px;
+    font-weight: 600;
+    color: white;
+    margin-bottom: 20px;
+    font-family: 'Inter', sans-serif;
+  }
+  
+  .footer-section ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+  
+  .footer-section li {
+    margin-bottom: 12px;
+  }
+  
+  .footer-section a {
+    color: #e2e8f0;
+    text-decoration: none;
+    font-size: 14px;
+    transition: color 0.3s ease;
+  }
+  
+  .footer-section a:hover {
+    color: var(--primary-color);
+  }
+  
+  .footer-section span {
+    color: #e2e8f0;
+    font-size: 14px;
+    line-height: 1.6;
   }
   
   .footer-social {
     display: flex;
-    gap: 15px;
+    gap: 12px;
+    margin-top: 10px;
   }
   
   .social-icon {
-    color: var(--text-color);
-    transition: color 0.3s ease;
+    color: #e2e8f0;
+    transition: all 0.3s ease;
     display: flex;
     align-items: center;
     justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    background-color: rgba(255, 255, 255, 0.1);
   }
   
   .social-icon:hover {
     color: var(--primary-color);
+    background-color: rgba(0, 225, 199, 0.1);
+    transform: translateY(-2px);
+  }
+  
+  .footer-bottom {
+    border-top: 1px solid rgba(255, 255, 255, 0.1);
+    padding-top: 30px;
+  }
+  
+  .footer-copyright {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 15px;
+  }
+  
+  .footer-copyright p {
+    margin: 0;
+    font-size: 14px;
+    color: #e2e8f0;
+  }
+  
+  .footer-made {
+    color: var(--primary-color) !important;
+    font-weight: 500;
+  }
+  
+  @media (max-width: 1024px) {
+    .footer-links {
+      grid-template-columns: repeat(2, 1fr);
+      gap: 25px;
+    }
   }
   
   @media (max-width: 768px) {
+    .footer {
+      padding: 40px 0 20px;
+    }
+    
     .footer-content {
-      flex-direction: column;
-      gap: 20px;
+      grid-template-columns: 1fr;
+      gap: 30px;
       text-align: center;
+    }
+    
+    .footer-links {
+      grid-template-columns: 1fr;
+      gap: 25px;
+    }
+    
+    .footer-copyright {
+      flex-direction: column;
+      text-align: center;
+      gap: 10px;
+    }
+    
+    .footer-social {
+      justify-content: center;
+    }
+  }
+  
+  @media (max-width: 480px) {
+    .footer {
+      padding: 30px 0 15px;
+    }
+    
+    .footer-content {
+      gap: 25px;
+    }
+    
+    .footer-links {
+      gap: 20px;
+    }
+    
+    .footer-section h4 {
+      font-size: 15px;
+      margin-bottom: 15px;
+    }
+    
+    .footer-section a,
+    .footer-section span {
+      font-size: 13px;
+    }
+    
+    .footer-logo a {
+      font-size: 24px;
+    }
+    
+    .footer-logo p {
+      font-size: 13px;
     }
   }
 </style>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,21 +1,29 @@
 ---
+import { useTranslations } from '../i18n';
+
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang as 'en' | 'es');
 ---
 
 <section class="hero" itemscope itemtype="https://schema.org/Organization">
   <div class="container">
     <div class="hero-content">
       <div class="hero-text">
-        <p class="subtitle" itemprop="description">CREATIVE DESIGN AGENCY</p>
-        <h1 itemprop="name">WE TRANSFORM <span class="primary-color">IDEAS</span> INTO REALITY</h1>
+        <p class="subtitle" itemprop="description">CREXATIVE</p>
+        <h1 itemprop="name">{t('hero.title')}</h1>
         <p class="description" itemprop="description">
-          We are a global creative design agency specializing in web design, mobile applications, and digital experiences. Our team of skilled designers and developers work remotely to deliver exceptional results for clients worldwide.
+          {t('hero.description')}
         </p>
         <div class="cta-buttons">
-          <a href="#contact" class="btn btn-primary" aria-label="Get a free consultation for your creative project">
-            Get Free Quote
+          <a href="#contact" class="btn btn-primary" aria-label={t('hero.cta')}>
+            {t('hero.cta')}
           </a>
-          <a href="#services" class="btn btn-secondary" aria-label="View our services">
-            Our Services
+          <a href="#services" class="btn btn-secondary" aria-label={t('hero.ctaSecondary')}>
+            {t('hero.ctaSecondary')}
           </a>
         </div>
       </div>
@@ -23,7 +31,7 @@
         <div class="image-container">
           <img 
             src="/images/hero.jpg" 
-            alt="CREXATIVE software development team working on innovative solutions in Medellín, Colombia"
+            alt={lang === 'es' ? 'Equipo de desarrollo de software CREXATIVE trabajando en soluciones innovadoras en Colombia' : 'CREXATIVE software development team working on innovative solutions in Colombia'}
             width="600"
             height="400"
             loading="eager"
@@ -117,12 +125,15 @@
     border-color: var(--text-color);
   }
 
+
   .btn-secondary:hover {
     background-color: var(--text-color);
     color: white;
     transform: translateY(-2px);
     box-shadow: 0 8px 20px rgba(0, 0, 0, 0.15);
   }
+
+  /* Dark mode styles will be handled globally in Layout.astro */
 
   .hero-image {
     flex: 1;

--- a/src/components/LanguageSwitcher.astro
+++ b/src/components/LanguageSwitcher.astro
@@ -1,0 +1,181 @@
+---
+import { languages } from '../i18n';
+
+interface Props {
+  currentLang: string;
+}
+
+const { currentLang } = Astro.props;
+---
+
+<div class="language-switcher">
+  <button id="lang-toggle" class="lang-button" aria-label="Switch Language">
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M5 8l6 6 6-6" />
+    </svg>
+    <span>{languages[currentLang as keyof typeof languages]}</span>
+  </button>
+  
+  <div id="lang-menu" class="lang-menu hidden">
+    {Object.entries(languages).map(([code, name]) => (
+      <button 
+        class={`lang-option ${currentLang === code ? 'active' : ''}`}
+        data-lang={code}
+        aria-label={`Switch to ${name}`}
+      >
+        {name}
+      </button>
+    ))}
+  </div>
+</div>
+
+<script>
+  const langToggle = document.getElementById('lang-toggle');
+  const langMenu = document.getElementById('lang-menu');
+  const langOptions = document.querySelectorAll('.lang-option');
+  
+  langToggle?.addEventListener('click', () => {
+    langMenu?.classList.toggle('hidden');
+  });
+  
+  // Close menu when clicking outside
+  document.addEventListener('click', (e) => {
+    if (!langToggle?.contains(e.target as Node) && !langMenu?.contains(e.target as Node)) {
+      langMenu?.classList.add('hidden');
+    }
+  });
+  
+  langOptions.forEach(option => {
+    option.addEventListener('click', (e) => {
+      const selectedLang = (e.target as HTMLElement).dataset.lang;
+      if (selectedLang) {
+        // Store language preference
+        localStorage.setItem('preferred-language', selectedLang);
+        
+        // Get current path without language prefix
+        const currentPath = window.location.pathname;
+        const pathWithoutLang = currentPath.replace(/^\/[a-z]{2}/, '') || '/';
+        
+        // Navigate to new language
+        const newPath = selectedLang === 'es' ? pathWithoutLang : `/${selectedLang}${pathWithoutLang}`;
+        window.location.href = newPath;
+      }
+    });
+  });
+</script>
+
+<style>
+  .language-switcher {
+    position: relative;
+  }
+  
+  .lang-button {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--border-color);
+    border-radius: 0.375rem;
+    background: var(--bg-color);
+    color: var(--text-color);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+  
+  .lang-button:hover {
+    background: var(--bg-secondary);
+    border-color: var(--primary-color);
+    color: var(--text-color);
+  }
+  
+  /* Dark mode specific styles */
+  [data-theme="dark"] .lang-button {
+    background: rgba(255, 255, 255, 0.1) !important;
+    border-color: rgba(255, 255, 255, 0.2) !important;
+    color: #e2e8f0 !important;
+  }
+  
+  [data-theme="dark"] .lang-button:hover {
+    background: rgba(0, 225, 199, 0.1) !important;
+    border-color: var(--primary-color) !important;
+    color: var(--primary-color) !important;
+  }
+  
+  .lang-button svg {
+    transition: transform 0.2s ease;
+  }
+  
+  .lang-button:hover svg {
+    transform: rotate(180deg);
+  }
+  
+  .lang-menu {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    margin-top: 0.5rem;
+    background: var(--bg-color);
+    border: 1px solid var(--border-color);
+    border-radius: 0.375rem;
+    box-shadow: var(--shadow-lg);
+    z-index: 50;
+    min-width: 120px;
+  }
+  
+  .lang-menu.hidden {
+    display: none;
+  }
+  
+  .lang-option {
+    display: block;
+    width: 100%;
+    padding: 0.75rem 1rem;
+    text-align: left;
+    background: none;
+    border: none;
+    color: var(--text-color);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.2s ease;
+  }
+  
+  .lang-option:hover {
+    background: var(--bg-secondary);
+    color: var(--text-color);
+  }
+  
+  .lang-option.active {
+    background: var(--primary-color);
+    color: white;
+  }
+  
+  /* Dark mode specific styles for menu */
+  [data-theme="dark"] .lang-menu {
+    background: rgba(10, 10, 10, 0.95) !important;
+    border-color: rgba(255, 255, 255, 0.1) !important;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5) !important;
+  }
+  
+  [data-theme="dark"] .lang-option {
+    color: #e2e8f0 !important;
+  }
+  
+  [data-theme="dark"] .lang-option:hover {
+    background: rgba(255, 255, 255, 0.1) !important;
+    color: var(--primary-color) !important;
+  }
+  
+  [data-theme="dark"] .lang-option.active {
+    background: var(--primary-color) !important;
+    color: #000 !important;
+  }
+  
+  .lang-option:first-child {
+    border-radius: 0.375rem 0.375rem 0 0;
+  }
+  
+  .lang-option:last-child {
+    border-radius: 0 0 0.375rem 0.375rem;
+  }
+</style>

--- a/src/components/Navbar.astro
+++ b/src/components/Navbar.astro
@@ -1,22 +1,32 @@
 ---
-import Layout from '../layouts/Layout.astro';
-const { brandName } = Astro.props;
+import LanguageSwitcher from './LanguageSwitcher.astro';
+import { useTranslations } from '../i18n';
+
+interface Props {
+  brandName: string;
+  lang: string;
+}
+
+const { brandName, lang } = Astro.props;
+const t = useTranslations(lang as 'en' | 'es');
 ---
 
 <header class="navbar">
   <div class="container">
     <div class="logo">
-      <a href="/">{brandName}</a>
+      <a href={lang === 'en' ? '/en' : '/'}>{brandName}</a>
     </div>
     <nav class="desktop-nav">
       <ul>
-        <li><a href="/">HOME</a></li>
-        <li><a href="#services">SERVICES</a></li>
-        <li><a href="#about">ABOUT</a></li>
-        <li><a href="#contact">CONTACT</a></li>
+        <li><a href={lang === 'en' ? '/en' : '/'}>{t('nav.home')}</a></li>
+        <li><a href="#services">{t('nav.services')}</a></li>
+        <li><a href="#about">{t('nav.about')}</a></li>
+        <li><a href="#contact">{t('nav.contact')}</a></li>
       </ul>
     </nav>
-    <div class="theme-toggle">
+    <div class="nav-actions">
+      <LanguageSwitcher currentLang={lang} />
+      <div class="theme-toggle">
       <button id="theme-toggle-btn" aria-label="Toggle theme">
         <svg class="sun-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
           <circle cx="12" cy="12" r="5"></circle>
@@ -33,6 +43,7 @@ const { brandName } = Astro.props;
           <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
         </svg>
       </button>
+      </div>
     </div>
     <button class="mobile-menu-toggle" aria-label="Toggle mobile menu">
       <span class="bar"></span>
@@ -43,10 +54,10 @@ const { brandName } = Astro.props;
   
   <div class="mobile-nav">
     <ul>
-      <li><a href="/">HOME</a></li>
-      <li><a href="#services">SERVICES</a></li>
-      <li><a href="#about">ABOUT</a></li>
-      <li><a href="#contact">CONTACT</a></li>
+      <li><a href={lang === 'en' ? '/en' : '/'}>{t('nav.home')}</a></li>
+      <li><a href="#services">{t('nav.services')}</a></li>
+      <li><a href="#about">{t('nav.about')}</a></li>
+      <li><a href="#contact">{t('nav.contact')}</a></li>
     </ul>
   </div>
 </header>
@@ -163,8 +174,14 @@ const { brandName } = Astro.props;
     color: var(--primary-color);
   }
 
+  .nav-actions {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+  }
+  
   .theme-toggle {
-    margin-right: 15px;
+    margin: 0;
   }
 
   #theme-toggle-btn {
@@ -294,8 +311,12 @@ const { brandName } = Astro.props;
       display: block;
     }
     
+    .nav-actions {
+      gap: 0.5rem;
+    }
+    
     .theme-toggle {
-      margin-right: 20px;
+      margin: 0;
     }
   }
 </style>

--- a/src/components/Services.astro
+++ b/src/components/Services.astro
@@ -1,45 +1,54 @@
 ---
+import { useTranslations } from '../i18n';
+
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang as 'en' | 'es');
+
 const services = [
   {
-    name: "Web Application Development",
-    description: "We build robust, scalable, and secure web applications tailored to your business needs, from single-page applications to complex enterprise systems using React, Node.js, and modern frameworks.",
-    icon: "web-development",
-    keywords: "web development, React, Node.js, full-stack development, responsive design"
+    name: t('services.web.title'),
+    description: t('services.web.description'),
+    icon: 'web-development',
+    techTags: ['React', 'Node.js', 'TypeScript']
   },
   {
-    name: "Mobile App Development", 
-    description: "We create beautiful and performant native and cross-platform mobile apps for both iOS and Android, delivering seamless user experiences with React Native and Flutter.",
-    icon: "mobile-development",
-    keywords: "mobile app development, iOS, Android, React Native, Flutter"
+    name: t('services.mobile.title'),
+    description: t('services.mobile.description'),
+    icon: 'mobile-development',
+    techTags: ['React Native', 'Flutter', 'iOS', 'Android']
   },
   {
-    name: "UI/UX Design & Prototyping",
-    description: "Our design team creates intuitive, user-centric interfaces and interactive prototypes that enhance usability and drive engagement using Figma and Adobe Creative Suite.",
-    icon: "ui-ux-design", 
-    keywords: "UI UX design, prototyping, user experience, interface design, Figma"
+    name: t('services.uiux.title'),
+    description: t('services.uiux.description'),
+    icon: 'ui-ux-design',
+    techTags: ['Figma', 'Adobe XD', 'Prototyping']
   },
   {
-    name: "E-commerce Solutions",
-    description: "We develop complete e-commerce platforms with secure payment integration, inventory management, and optimized checkout processes to maximize your online sales.",
-    icon: "ecommerce",
-    keywords: "e-commerce development, online store, payment integration, Shopify, WooCommerce"
+    name: t('services.ecommerce.title'),
+    description: t('services.ecommerce.description'),
+    icon: 'ecommerce',
+    techTags: ['Shopify', 'WooCommerce', t('misc.paymentIntegration')]
   }
 ];
 
 const structuredData = {
-  "@context": "https://schema.org",
-  "@type": "Service",
-  "provider": {
-    "@type": "Organization",
-    "name": "CREXATIVE",
-    "url": "https://crexative.com"
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  provider: {
+    '@type': 'Organization',
+    name: 'CREXATIVE',
+    url: 'https://crexative.com'
   },
-  "serviceType": "Software Development",
-  "offers": services.map(service => ({
-    "@type": "Offer",
-    "name": service.name,
-    "description": service.description,
-    "category": "Software Development"
+  serviceType: 'Software Development',
+  offers: services.map(service => ({
+    '@type': 'Offer',
+    name: service.name,
+    description: service.description,
+    category: 'Software Development'
   }))
 };
 ---
@@ -47,84 +56,59 @@ const structuredData = {
 <section id="services" class="services" itemscope itemtype="https://schema.org/Organization">
   <div class="container">
     <div class="section-header">
-      <p class="subtitle">OUR SERVICES</p>
-      <h2>WHAT WE <span class="primary-color">DO</span>?</h2>
+      <p class="subtitle">{t('services.title')}</p>
+      <h2>{t('services.subtitle')}</h2>
       <p class="section-description">
-        We provide comprehensive software development services to help businesses thrive in the digital age. Our expert team delivers cutting-edge solutions tailored to your specific needs.
+        {t('services.subtitle')}
       </p>
     </div>
     
     <div class="services-grid" itemprop="makesOffer" itemscope itemtype="https://schema.org/Offer">
-      <article class="service-card" itemscope itemtype="https://schema.org/Service">
-        <div class="service-icon">
+      {services.map((service, index) => {
+        const icons = [
+          // Web Development Icon
           <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect>
             <line x1="3" y1="9" x2="21" y2="9"></line>
             <line x1="9" y1="21" x2="9" y2="9"></line>
-          </svg>
-        </div>
-        <h3 itemprop="name">Website Design</h3>
-        <p itemprop="description">Custom website design and development tailored to your brand and business goals, fully responsive and optimized for performance.</p>
-        <div class="service-tech">
-          <span class="tech-tag">React</span>
-          <span class="tech-tag">Node.js</span>
-          <span class="tech-tag">TypeScript</span>
-        </div>
-      </article>
-      
-      <article class="service-card" itemscope itemtype="https://schema.org/Service">
-        <div class="service-icon">
+          </svg>,
+          // Mobile Development Icon
           <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <rect x="5" y="2" width="14" height="20" rx="2" ry="2"></rect>
             <line x1="12" y1="18" x2="12" y2="18"></line>
-          </svg>
-        </div>
-        <h3 itemprop="name">Mobile & Desktop App</h3>
-        <p itemprop="description">Native and cross-platform mobile applications, plus desktop software solutions designed for seamless user experiences across all devices.</p>
-        <div class="service-tech">
-          <span class="tech-tag">React Native</span>
-          <span class="tech-tag">Flutter</span>
-          <span class="tech-tag">iOS</span>
-          <span class="tech-tag">Android</span>
-        </div>
-      </article>
-      
-      <article class="service-card" itemscope itemtype="https://schema.org/Service">
-        <div class="service-icon">
+          </svg>,
+          // UI/UX Design Icon
           <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <path d="M17 3a2.828 2.828 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5L17 3z"></path>
-          </svg>
-        </div>
-        <h3 itemprop="name">UI & UX Design</h3>
-        <p itemprop="description">User-centered design solutions that prioritize usability and aesthetics, creating intuitive interfaces that engage and convert users.</p>
-        <div class="service-tech">
-          <span class="tech-tag">Figma</span>
-          <span class="tech-tag">Adobe XD</span>
-          <span class="tech-tag">Prototyping</span>
-        </div>
-      </article>
-      
-      <article class="service-card" itemscope itemtype="https://schema.org/Service">
-        <div class="service-icon">
+          </svg>,
+          // E-commerce Icon
           <svg xmlns="http://www.w3.org/2000/svg" width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <circle cx="8" cy="21" r="1"></circle>
             <circle cx="19" cy="21" r="1"></circle>
             <path d="M2.05 2.05h2l2.66 12.42a2 2 0 0 0 2 1.58h9.78a2 2 0 0 0 1.95-1.57l1.65-7.43H5.12"></path>
           </svg>
-        </div>
-        <h3 itemprop="name">Visual Content Creation</h3>
-        <p itemprop="description">Professional photo editing, graphic design, and visual content creation to enhance your brand's visual identity and marketing materials.</p>
-        <div class="service-tech">
-          <span class="tech-tag">Shopify</span>
-          <span class="tech-tag">WooCommerce</span>
-          <span class="tech-tag">Payment Integration</span>
-        </div>
-      </article>
+        ];
+        
+        return (
+          <article class="service-card" itemscope itemtype="https://schema.org/Service">
+            <div class="service-icon">
+              {icons[index]}
+            </div>
+            <h3 itemprop="name">{service.name}</h3>
+            <p itemprop="description">{service.description}</p>
+            <div class="service-tech">
+              {service.techTags.map(tag => (
+                <span class="tech-tag">{tag}</span>
+              ))}
+            </div>
+          </article>
+        );
+      })}
     </div>
   </div>
   
   <!-- Structured Data -->
-  <script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+  <script type="application/ld+json" set:html={JSON.stringify(structuredData)} is:inline />
 </section>
 
 <style>

--- a/src/components/StickyCallToAction.astro
+++ b/src/components/StickyCallToAction.astro
@@ -1,18 +1,25 @@
 ---
-// Sticky CTA button component
+import { useTranslations } from '../i18n';
+
+interface Props {
+  lang: string;
+}
+
+const { lang } = Astro.props;
+const t = useTranslations(lang as 'en' | 'es');
 ---
 
 <div class="sticky-cta" id="stickyCTA">
-  <a href="#contact" class="sticky-btn" aria-label="Get free quote">
+  <a href="#contact" class="sticky-btn" aria-label={t('sticky.cta')}>
     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
       <line x1="22" y1="2" x2="11" y2="13"></line>
       <polygon points="22,2 15,22 11,13 2,9 22,2"></polygon>
     </svg>
-    <span class="sticky-text">Get Quote</span>
+    <span class="sticky-text">{t('sticky.cta')}</span>
   </a>
   
   <div class="sticky-tooltip">
-    Get your free consultation now!
+    {t('sticky.subtitle')}
   </div>
 </div>
 

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,152 @@
+import en from './locales/en';
+import es from './locales/es';
+
+export const languages = {
+  en: 'English',
+  es: 'Español',
+};
+
+export const defaultLang = 'es';
+
+export const translations = {
+  en,
+  es,
+};
+
+export function getLangFromUrl(url: URL) {
+  const [, lang] = url.pathname.split('/');
+  if (lang in languages) return lang as keyof typeof languages;
+  return defaultLang;
+}
+
+export function useTranslations(lang: keyof typeof languages) {
+  return function t(key: string) {
+    const keys = key.split('.');
+    let value: any = translations[lang];
+    
+    for (const k of keys) {
+      value = value?.[k];
+    }
+    
+    // Fallback to English if translation not found
+    if (!value) {
+      let fallback: any = translations[defaultLang];
+      for (const k of keys) {
+        fallback = fallback?.[k];
+      }
+      value = fallback;
+    }
+    
+    return value || key;
+  };
+}
+
+export type TranslationKey = 
+  | 'nav.home'
+  | 'nav.services'
+  | 'nav.about'
+  | 'nav.contact'
+  | 'nav.portfolio'
+  | 'hero.title'
+  | 'hero.subtitle'
+  | 'hero.description'
+  | 'hero.cta'
+  | 'hero.ctaSecondary'
+  | 'services.title'
+  | 'services.subtitle'
+  | 'services.web.title'
+  | 'services.web.description'
+  | 'services.mobile.title'
+  | 'services.mobile.description'
+  | 'services.uiux.title'
+  | 'services.uiux.description'
+  | 'services.ecommerce.title'
+  | 'services.ecommerce.description'
+  | 'services.custom.title'
+  | 'services.custom.description'
+  | 'services.consulting.title'
+  | 'services.consulting.description'
+  | 'about.title'
+  | 'about.subtitle'
+  | 'about.description'
+  | 'about.mission'
+  | 'about.vision'
+  | 'about.stats.experience'
+  | 'about.stats.projects'
+  | 'about.stats.clients'
+  | 'about.stats.team'
+  | 'about.values.innovation'
+  | 'about.values.innovationDesc'
+  | 'about.values.quality'
+  | 'about.values.qualityDesc'
+  | 'about.values.partnership'
+  | 'about.values.partnershipDesc'
+  | 'contact.title'
+  | 'contact.subtitle'
+  | 'contact.description'
+  | 'contact.form.name'
+  | 'contact.form.namePlaceholder'
+  | 'contact.form.email'
+  | 'contact.form.emailPlaceholder'
+  | 'contact.form.phone'
+  | 'contact.form.phonePlaceholder'
+  | 'contact.form.company'
+  | 'contact.form.companyPlaceholder'
+  | 'contact.form.service'
+  | 'contact.form.servicePlaceholder'
+  | 'contact.form.message'
+  | 'contact.form.messagePlaceholder'
+  | 'contact.form.submit'
+  | 'contact.form.sending'
+  | 'contact.form.success'
+  | 'contact.form.error'
+  | 'contact.info.phone'
+  | 'contact.info.email'
+  | 'contact.info.address'
+  | 'contact.info.hours'
+  | 'contact.details.phone'
+  | 'contact.details.email'
+  | 'contact.details.address'
+  | 'contact.details.hours'
+  | 'footer.description'
+  | 'footer.sections.company'
+  | 'footer.sections.services'
+  | 'footer.sections.contact'
+  | 'footer.sections.follow'
+  | 'footer.links.home'
+  | 'footer.links.about'
+  | 'footer.links.services'
+  | 'footer.links.portfolio'
+  | 'footer.links.contact'
+  | 'footer.links.privacy'
+  | 'footer.links.terms'
+  | 'footer.servicesList.web'
+  | 'footer.servicesList.mobile'
+  | 'footer.servicesList.uiux'
+  | 'footer.servicesList.ecommerce'
+  | 'footer.servicesList.custom'
+  | 'footer.servicesList.consulting'
+  | 'footer.social.linkedin'
+  | 'footer.social.twitter'
+  | 'footer.social.github'
+  | 'footer.social.instagram'
+  | 'footer.copyright'
+  | 'footer.madeWith'
+  | 'sticky.title'
+  | 'sticky.subtitle'
+  | 'sticky.cta'
+  | 'sticky.ctaSecondary'
+  | 'seo.title'
+  | 'seo.description'
+  | 'seo.keywords'
+  | 'common.learnMore'
+  | 'common.getStarted'
+  | 'common.viewMore'
+  | 'common.readMore'
+  | 'common.close'
+  | 'common.back'
+  | 'common.next'
+  | 'common.previous'
+  | 'common.loading'
+  | 'common.error'
+  | 'common.success';

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -1,0 +1,210 @@
+export default {
+  // Navigation
+  nav: {
+    home: 'Home',
+    services: 'Services',
+    about: 'About',
+    contact: 'Contact',
+    portfolio: 'Portfolio',
+  },
+
+  // Hero Section
+  hero: {
+    title: 'Transform Your Business with Custom Software Solutions',
+    subtitle: 'Expert web development, mobile apps, UI/UX design, and e-commerce solutions across Colombia',
+    description: 'We deliver innovative digital solutions that drive growth and success for businesses of all sizes.',
+    cta: 'Get Started',
+    ctaSecondary: 'View Our Work',
+  },
+
+  // Services Section
+  services: {
+    title: 'Our Services',
+    subtitle: 'Comprehensive software development solutions tailored to your needs',
+    web: {
+      title: 'Web Development',
+      description: 'Modern, responsive websites and web applications built with cutting-edge technologies like React, Next.js, and Node.js.',
+    },
+    mobile: {
+      title: 'Mobile Apps',
+      description: 'Native and cross-platform mobile applications for iOS and Android using React Native and Flutter.',
+    },
+    uiux: {
+      title: 'UI/UX Design',
+      description: 'User-centered design solutions that enhance user experience and engagement with modern design principles.',
+    },
+    ecommerce: {
+      title: 'E-commerce',
+      description: 'Complete online store solutions with secure payment integration and inventory management systems.',
+    },
+    custom: {
+      title: 'Custom Software',
+      description: 'Tailored software solutions to meet your specific business requirements and workflow automation.',
+    },
+    consulting: {
+      title: 'Tech Consulting',
+      description: 'Strategic technology consulting to guide your digital transformation and technology stack decisions.',
+    },
+  },
+
+  // About Section
+  about: {
+    title: 'About CREXATIVE',
+    subtitle: 'Your trusted partner in digital transformation',
+    description: 'We are a team of passionate developers and designers committed to delivering high-quality software solutions. With over 5 years of experience and 100+ successful projects, we help businesses across Colombia achieve their digital goals.',
+    mission: 'Our mission is to empower businesses through innovative technology solutions that drive growth and efficiency.',
+    vision: 'We envision a future where every business can leverage technology to reach its full potential.',
+    stats: {
+      experience: 'Years of Experience',
+      projects: 'Projects Completed',
+      clients: 'Happy Clients',
+      team: 'Team Members',
+    },
+    values: {
+      innovation: 'Innovation',
+      innovationDesc: 'We stay ahead of technology trends to provide cutting-edge solutions.',
+      quality: 'Quality',
+      qualityDesc: 'We maintain the highest standards in code quality and project delivery.',
+      partnership: 'Partnership',
+      partnershipDesc: 'We work closely with our clients as true partners in their success.',
+    },
+  },
+
+  // Contact Section
+  contact: {
+    title: 'Get In Touch',
+    subtitle: 'Ready to start your project? Let\'s talk!',
+    description: 'We\'d love to hear about your project and discuss how we can help you achieve your goals.',
+    form: {
+      name: 'Full Name',
+      namePlaceholder: 'Enter your full name',
+      email: 'Email Address',
+      emailPlaceholder: 'Enter your email address',
+      phone: 'Phone Number',
+      phonePlaceholder: 'Enter your phone number',
+      company: 'Company',
+      companyPlaceholder: 'Enter your company name',
+      service: 'Service Needed',
+      servicePlaceholder: 'Select a service',
+      message: 'Message',
+      messagePlaceholder: 'Tell us about your project...',
+      submit: 'Send Message',
+      sending: 'Sending...',
+      success: 'Message sent successfully!',
+      error: 'Error sending message. Please try again.',
+    },
+    info: {
+      phone: 'Phone',
+      email: 'Email',
+      address: 'Address',
+      hours: 'Business Hours',
+    },
+    details: {
+      phone: '+57 (300) 123-4567',
+      email: 'hello@crexative.com',
+      address: 'Colombia',
+      hours: 'Mon - Fri: 9:00 AM - 6:00 PM',
+    },
+  },
+
+  // Footer
+  footer: {
+    description: 'Premium software development agency delivering innovative solutions across Colombia',
+    sections: {
+      company: 'Company',
+      services: 'Services',
+      contact: 'Contact Info',
+      follow: 'Follow Us',
+    },
+    links: {
+      home: 'Home',
+      about: 'About Us',
+      services: 'Services',
+      portfolio: 'Portfolio',
+      contact: 'Contact',
+      privacy: 'Privacy Policy',
+      terms: 'Terms of Service',
+    },
+    servicesList: {
+      web: 'Web Development',
+      mobile: 'Mobile Apps',
+      uiux: 'UI/UX Design',
+      ecommerce: 'E-commerce',
+      custom: 'Custom Software',
+      consulting: 'Consulting',
+    },
+    social: {
+      linkedin: 'LinkedIn',
+      twitter: 'Twitter',
+      github: 'GitHub',
+      instagram: 'Instagram',
+    },
+    copyright: 'All rights reserved.',
+    madeWith: 'Made with ❤️ in Colombia',
+  },
+
+  // Sticky CTA
+  sticky: {
+    title: 'Start Your Project',
+    subtitle: 'Ready to transform your business?',
+    cta: 'Get Started',
+    ctaSecondary: 'Learn More',
+  },
+
+  // SEO
+  seo: {
+    title: 'CREXATIVE - Software Development Agency in Colombia',
+    description: 'Transform your business with custom software solutions. Expert web development, mobile apps, UI/UX design, and e-commerce solutions. 5+ years experience, 100+ projects delivered.',
+    keywords: 'software development agency, web development, mobile app development, UI UX design, custom software solutions, React development, Node.js development, e-commerce development, Colombia, software company',
+  },
+
+  // Common
+  common: {
+    learnMore: 'Learn More',
+    getStarted: 'Get Started',
+    viewMore: 'View More',
+    readMore: 'Read More',
+    close: 'Close',
+    back: 'Back',
+    next: 'Next',
+    previous: 'Previous',
+    loading: 'Loading...',
+    error: 'Error',
+    success: 'Success',
+  },
+
+  // Social Links
+  social: {
+    facebook: 'https://www.facebook.com/crexative',
+    instagram: 'https://www.instagram.com/crexative.co',
+    youtube: 'https://www.youtube.com/@crexative',
+    linkedin: 'https://www.linkedin.com/company/crexative',
+    twitter: 'https://x.com/crexativer',
+  },
+
+  // Additional translations for hardcoded text
+  misc: {
+    responseTime: 'Response within 24 hours',
+    scheduleConsultation: 'Schedule online consultation',
+    workingGlobally: 'Working with clients globally',
+    mondayFriday: 'Monday - Friday:',
+    saturday: 'Saturday:',
+    sunday: 'Sunday:',
+    closed: 'Closed',
+    saturdayHours: '10:00 AM - 2:00 PM COT',
+    getQuote: 'Get Your Free Quote',
+    quoteDescription: 'Tell us about your project and we\'ll provide a detailed proposal within 48 hours.',
+    projectBudget: 'Project Budget',
+    selectBudget: 'Select budget range',
+    under5k: 'Under $5,000',
+    over50k: '$50,000+',
+    other: 'Other',
+    cleanCode: 'Clean Code',
+    cleanCodeDesc: 'We write maintainable, scalable code that follows industry best practices and ensures long-term project success.',
+    modernDesign: 'Modern Design',
+    modernDesignDesc: 'Our designs blend contemporary aesthetics with functional usability, creating experiences that are both beautiful and effective.',
+    scalableArchitecture: 'Scalable Architecture',
+    scalableArchitectureDesc: 'We design and implement robust, scalable architectures that grow with your business, ensuring optimal performance and reliability at any scale.',
+    paymentIntegration: 'Payment Integration',
+  },
+};

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -1,0 +1,210 @@
+export default {
+  // Navigation
+  nav: {
+    home: 'Inicio',
+    services: 'Servicios',
+    about: 'Acerca de',
+    contact: 'Contacto',
+    portfolio: 'Portafolio',
+  },
+
+  // Hero Section
+  hero: {
+    title: 'Transforma Tu Negocio con Soluciones de Software Personalizadas',
+    subtitle: 'Desarrollo web experto, aplicaciones móviles, diseño UI/UX y soluciones de e-commerce en toda Colombia',
+    description: 'Entregamos soluciones digitales innovadoras que impulsan el crecimiento y el éxito de empresas de todos los tamaños.',
+    cta: 'Comenzar',
+    ctaSecondary: 'Ver Nuestro Trabajo',
+  },
+
+  // Services Section
+  services: {
+    title: 'Nuestros Servicios',
+    subtitle: 'Soluciones integrales de desarrollo de software adaptadas a tus necesidades',
+    web: {
+      title: 'Desarrollo Web',
+      description: 'Sitios web modernos y responsivos y aplicaciones web construidas con tecnologías de vanguardia como React, Next.js y Node.js.',
+    },
+    mobile: {
+      title: 'Aplicaciones Móviles',
+      description: 'Aplicaciones móviles nativas y multiplataforma para iOS y Android usando React Native y Flutter.',
+    },
+    uiux: {
+      title: 'Diseño UI/UX',
+      description: 'Soluciones de diseño centradas en el usuario que mejoran la experiencia del usuario y el engagement con principios de diseño moderno.',
+    },
+    ecommerce: {
+      title: 'E-commerce',
+      description: 'Soluciones completas de tienda online con integración de pagos seguros y sistemas de gestión de inventario.',
+    },
+    custom: {
+      title: 'Software Personalizado',
+      description: 'Soluciones de software a medida para satisfacer tus requisitos específicos de negocio y automatización de flujos de trabajo.',
+    },
+    consulting: {
+      title: 'Consultoría Tecnológica',
+      description: 'Consultoría tecnológica estratégica para guiar tu transformación digital y decisiones de stack tecnológico.',
+    },
+  },
+
+  // About Section
+  about: {
+    title: 'Acerca de CREXATIVE',
+    subtitle: 'Tu socio confiable en transformación digital',
+    description: 'Somos un equipo de desarrolladores y diseñadores apasionados comprometidos con entregar soluciones de software de alta calidad. Con más de 5 años de experiencia y 100+ proyectos exitosos, ayudamos a empresas en toda Colombia a alcanzar sus objetivos digitales.',
+    mission: 'Nuestra misión es empoderar a las empresas a través de soluciones tecnológicas innovadoras que impulsan el crecimiento y la eficiencia.',
+    vision: 'Visualizamos un futuro donde cada empresa pueda aprovechar la tecnología para alcanzar su máximo potencial.',
+    stats: {
+      experience: 'Años de Experiencia',
+      projects: 'Proyectos Completados',
+      clients: 'Clientes Satisfechos',
+      team: 'Miembros del Equipo',
+    },
+    values: {
+      innovation: 'Innovación',
+      innovationDesc: 'Nos mantenemos a la vanguardia de las tendencias tecnológicas para proporcionar soluciones de vanguardia.',
+      quality: 'Calidad',
+      qualityDesc: 'Mantenemos los más altos estándares en calidad de código y entrega de proyectos.',
+      partnership: 'Colaboración',
+      partnershipDesc: 'Trabajamos estrechamente con nuestros clientes como verdaderos socios en su éxito.',
+    },
+  },
+
+  // Contact Section
+  contact: {
+    title: 'Contáctanos',
+    subtitle: '¿Listo para iniciar tu proyecto? ¡Hablemos!',
+    description: 'Nos encantaría conocer tu proyecto y discutir cómo podemos ayudarte a alcanzar tus objetivos.',
+    form: {
+      name: 'Nombre Completo',
+      namePlaceholder: 'Ingresa tu nombre completo',
+      email: 'Correo Electrónico',
+      emailPlaceholder: 'Ingresa tu correo electrónico',
+      phone: 'Número de Teléfono',
+      phonePlaceholder: 'Ingresa tu número de teléfono',
+      company: 'Empresa',
+      companyPlaceholder: 'Ingresa el nombre de tu empresa',
+      service: 'Servicio Requerido',
+      servicePlaceholder: 'Selecciona un servicio',
+      message: 'Mensaje',
+      messagePlaceholder: 'Cuéntanos sobre tu proyecto...',
+      submit: 'Enviar Mensaje',
+      sending: 'Enviando...',
+      success: '¡Mensaje enviado exitosamente!',
+      error: 'Error al enviar el mensaje. Por favor intenta de nuevo.',
+    },
+    info: {
+      phone: 'Teléfono',
+      email: 'Correo',
+      address: 'Dirección',
+      hours: 'Horario de Atención',
+    },
+    details: {
+      phone: '+57 (300) 123-4567',
+      email: 'hola@crexative.com',
+      address: 'Colombia',
+      hours: 'Lun - Vie: 9:00 AM - 6:00 PM',
+    },
+  },
+
+  // Footer
+  footer: {
+    description: 'Agencia de desarrollo de software premium que ofrece soluciones innovadoras en toda Colombia',
+    sections: {
+      company: 'Empresa',
+      services: 'Servicios',
+      contact: 'Información de Contacto',
+      follow: 'Síguenos',
+    },
+    links: {
+      home: 'Inicio',
+      about: 'Acerca de',
+      services: 'Servicios',
+      portfolio: 'Portafolio',
+      contact: 'Contacto',
+      privacy: 'Política de Privacidad',
+      terms: 'Términos de Servicio',
+    },
+    servicesList: {
+      web: 'Desarrollo Web',
+      mobile: 'Aplicaciones Móviles',
+      uiux: 'Diseño UI/UX',
+      ecommerce: 'E-commerce',
+      custom: 'Software Personalizado',
+      consulting: 'Consultoría',
+    },
+    social: {
+      linkedin: 'LinkedIn',
+      twitter: 'Twitter',
+      github: 'GitHub',
+      instagram: 'Instagram',
+    },
+    copyright: 'Todos los derechos reservados.',
+    madeWith: 'Hecho con ❤️ en Colombia',
+  },
+
+  // Sticky CTA
+  sticky: {
+    title: 'Inicia Tu Proyecto',
+    subtitle: '¿Listo para transformar tu negocio?',
+    cta: 'Comenzar',
+    ctaSecondary: 'Conoce Más',
+  },
+
+  // SEO
+  seo: {
+    title: 'CREXATIVE - Agencia de Desarrollo de Software en Colombia',
+    description: 'Transforma tu negocio con soluciones de software personalizadas. Desarrollo web experto, aplicaciones móviles, diseño UI/UX y soluciones de e-commerce. 5+ años de experiencia, 100+ proyectos entregados.',
+    keywords: 'agencia desarrollo software, desarrollo web, desarrollo aplicaciones móviles, diseño UI UX, soluciones software personalizado, desarrollo React, desarrollo Node.js, desarrollo e-commerce, Colombia, empresa software',
+  },
+
+  // Common
+  common: {
+    learnMore: 'Conoce Más',
+    getStarted: 'Comenzar',
+    viewMore: 'Ver Más',
+    readMore: 'Leer Más',
+    close: 'Cerrar',
+    back: 'Atrás',
+    next: 'Siguiente',
+    previous: 'Anterior',
+    loading: 'Cargando...',
+    error: 'Error',
+    success: 'Éxito',
+  },
+
+  // Social Links
+  social: {
+    facebook: 'https://www.facebook.com/crexative',
+    instagram: 'https://www.instagram.com/crexative.co',
+    youtube: 'https://www.youtube.com/@crexative',
+    linkedin: 'https://www.linkedin.com/company/crexative',
+    twitter: 'https://x.com/crexativer',
+  },
+
+  // Additional translations for hardcoded text
+  misc: {
+    responseTime: 'Respuesta en 24 horas',
+    scheduleConsultation: 'Programar consulta online',
+    workingGlobally: 'Trabajando con clientes globalmente',
+    mondayFriday: 'Lunes - Viernes:',
+    saturday: 'Sábado:',
+    sunday: 'Domingo:',
+    closed: 'Cerrado',
+    saturdayHours: '10:00 AM - 2:00 PM COT',
+    getQuote: 'Obtén Tu Cotización Gratuita',
+    quoteDescription: 'Cuéntanos sobre tu proyecto y te proporcionaremos una propuesta detallada en 48 horas.',
+    projectBudget: 'Presupuesto del Proyecto',
+    selectBudget: 'Seleccionar rango de presupuesto',
+    under5k: 'Menos de $5,000',
+    over50k: '$50,000+',
+    other: 'Otro',
+    cleanCode: 'Código Limpio',
+    cleanCodeDesc: 'Escribimos código mantenible y escalable que sigue las mejores prácticas de la industria y asegura el éxito a largo plazo del proyecto.',
+    modernDesign: 'Diseño Moderno',
+    modernDesignDesc: 'Nuestros diseños combinan estética contemporánea con usabilidad funcional, creando experiencias que son tanto hermosas como efectivas.',
+    scalableArchitecture: 'Arquitectura Escalable',
+    scalableArchitectureDesc: 'Diseñamos e implementamos arquitecturas robustas y escalables que crecen con tu negocio, asegurando rendimiento óptimo y confiabilidad a cualquier escala.',
+    paymentIntegration: 'Integración de Pagos',
+  },
+};

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -1,17 +1,23 @@
 ---
+import { getLangFromUrl, useTranslations } from '../i18n';
+
 export interface Props {
 	title?: string;
 	description?: string;
 	keywords?: string;
 	image?: string;
 	canonical?: string;
+	lang?: string;
 }
 
 const brandName = "CREXATIVE";
+const currentLang = Astro.props.lang || getLangFromUrl(Astro.url) || 'en';
+const t = useTranslations(currentLang as 'en' | 'es');
+
 const { 
-	title = `${brandName} - Software Development Agency in Colombia`,
-	description = "Transform your business with custom software solutions. Expert web development, mobile apps, UI/UX design, and e-commerce solutions. 5+ years experience, 100+ projects delivered.",
-	keywords = "software development, web development, mobile app development, UI UX design, e-commerce, custom software, Colombia, software agency, React, Node.js, Python, JavaScript",
+	title = t('seo.title'),
+	description = t('seo.description'),
+	keywords = t('seo.keywords'),
 	image = "/images/crexative-og.png",
 	canonical = Astro.url.href
 } = Astro.props;
@@ -52,7 +58,7 @@ const structuredData = {
 ---
 
 <!doctype html>
-<html lang="en" data-theme="light">
+<html lang={currentLang} data-theme="light">
 	<head>
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -65,7 +71,7 @@ const structuredData = {
 		<meta name="description" content={description} />
 		<meta name="keywords" content={keywords} />
 		<meta name="robots" content="index, follow" />
-		<meta name="language" content="English" />
+		<meta name="language" content={currentLang === 'es' ? 'Spanish' : 'English'} />
 		<meta name="author" content="CREXATIVE" />
 		<link rel="canonical" href={canonical} />
 		
@@ -76,7 +82,7 @@ const structuredData = {
 		<meta property="og:description" content={description} />
 		<meta property="og:image" content={image} />
 		<meta property="og:site_name" content="CREXATIVE" />
-		<meta property="og:locale" content="en_US" />
+		<meta property="og:locale" content={currentLang === 'es' ? 'es_CO' : 'en_US'} />
 		
 		<!-- Twitter -->
 		<meta property="twitter:card" content="summary_large_image" />
@@ -91,7 +97,7 @@ const structuredData = {
 		<meta name="geo.placename" content="Colombia" />
 		
 		<!-- Structured Data -->
-		<script type="application/ld+json" set:html={JSON.stringify(structuredData)} />
+		<script type="application/ld+json" set:html={JSON.stringify(structuredData)} is:inline />
 		
 		<!-- DNS Prefetch for external resources -->
 		<link rel="dns-prefetch" href="//fonts.googleapis.com">
@@ -102,7 +108,7 @@ const structuredData = {
 		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 		
 		<!-- Enhanced typography with modern font combination -->
-		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet" media="print" onload="this.media='all'">
+		<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet" onload="this.media='all'">
 		<noscript><link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Playfair+Display:wght@400;500;600;700&display=swap" rel="stylesheet"></noscript>
 		
 		<!-- Preload critical resources -->
@@ -171,11 +177,34 @@ const structuredData = {
 	/* Dark theme */
 	[data-theme="dark"] {
 		--bg-color: #0a0a0a;
+		--bg-secondary: #1a1a1a;
+		--bg-tertiary: #2a2a2a;
 		--text-color: #ffffff;
-		--text-gray: #aaaaaa;
+		--text-secondary: #e2e8f0;
+		--text-gray: #a0aec0;
+		--text-light: #718096;
 		--navbar-bg: rgba(10, 10, 10, 0.8);
 		--footer-bg: rgba(10, 10, 10, 0.9);
-		--border-color: rgba(255, 255, 255, 0.05);
+		--border-color: rgba(255, 255, 255, 0.1);
+		--shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.3);
+		--shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.4);
+		--shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.4);
+		--shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.5);
+	}
+
+	/* Dark mode button fixes - Global styles */
+	[data-theme="dark"] .btn-secondary:hover {
+		background-color: #e2e8f0 !important;
+		color: #000000 !important;
+		border-color: #00e1c7 !important;
+		transform: translateY(-2px) !important;
+		box-shadow: 0 8px 20px rgba(0, 225, 199, 0.3) !important;
+	}
+
+	[data-theme="dark"] .btn-secondary {
+		color: #e2e8f0 !important;
+		border-color: #e2e8f0 !important;
+		background-color: transparent !important;
 	}
 
 	html,

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -9,9 +9,9 @@ export interface Props {
 
 const brandName = "CREXATIVE";
 const { 
-	title = `${brandName} - Premium Software Development Agency in Medellín, Colombia`,
-	description = "Transform your business with custom software solutions. Expert web development, mobile apps, UI/UX design, and e-commerce solutions in Medellín, Colombia. 5+ years experience, 100+ projects delivered.",
-	keywords = "software development, web development, mobile app development, UI UX design, e-commerce, custom software, Medellín, Colombia, software agency, React, Node.js, Python, JavaScript",
+	title = `${brandName} - Software Development Agency in Colombia`,
+	description = "Transform your business with custom software solutions. Expert web development, mobile apps, UI/UX design, and e-commerce solutions. 5+ years experience, 100+ projects delivered.",
+	keywords = "software development, web development, mobile app development, UI UX design, e-commerce, custom software, Colombia, software agency, React, Node.js, Python, JavaScript",
 	image = "/images/crexative-og.png",
 	canonical = Astro.url.href
 } = Astro.props;
@@ -32,8 +32,6 @@ const structuredData = {
 	},
 	"address": {
 		"@type": "PostalAddress",
-		"addressLocality": "Medellín",
-		"addressRegion": "Antioquia",
 		"addressCountry": "CO"
 	},
 	"sameAs": [
@@ -89,10 +87,8 @@ const structuredData = {
 		<meta property="twitter:creator" content="@crexative" />
 		
 		<!-- Additional SEO Meta Tags -->
-		<meta name="geo.region" content="CO-ANT" />
-		<meta name="geo.placename" content="Medellín" />
-		<meta name="geo.position" content="6.2442;-75.5812" />
-		<meta name="ICBM" content="6.2442, -75.5812" />
+		<meta name="geo.region" content="CO" />
+		<meta name="geo.placename" content="Colombia" />
 		
 		<!-- Structured Data -->
 		<script type="application/ld+json" set:html={JSON.stringify(structuredData)} />

--- a/src/pages/en/index.astro
+++ b/src/pages/en/index.astro
@@ -1,0 +1,36 @@
+---
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import About from '../../components/About.astro';
+import Contact from '../../components/Contact.astro';
+import Footer from '../../components/Footer.astro';
+import StickyCallToAction from '../../components/StickyCallToAction.astro';
+import { useTranslations } from '../../i18n';
+
+const t = useTranslations('en');
+const brandName = "CREXATIVE";
+
+// SEO-optimized meta data for English homepage
+const pageTitle = t('seo.title');
+const pageDescription = t('seo.description');
+const pageKeywords = t('seo.keywords');
+---
+
+<Layout 
+	title={pageTitle}
+	description={pageDescription}
+	keywords={pageKeywords}
+	image="https://crexative.com/images/crexative-og.png"
+	canonical="https://crexative.com/en/"
+	lang="en"
+>
+	<Navbar brandName={brandName} lang="en" />
+	<Hero lang="en" />
+	<Services lang="en" />
+	<About lang="en" />
+	<Contact lang="en" />
+	<Footer lang="en" />
+	<StickyCallToAction lang="en" />
+</Layout>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -1,13 +1,13 @@
 ---
-import Layout from '../layouts/Layout.astro';
-import Navbar from '../components/Navbar.astro';
-import Hero from '../components/Hero.astro';
-import Services from '../components/Services.astro';
-import About from '../components/About.astro';
-import Contact from '../components/Contact.astro';
-import Footer from '../components/Footer.astro';
-import StickyCallToAction from '../components/StickyCallToAction.astro';
-import { useTranslations } from '../i18n';
+import Layout from '../../layouts/Layout.astro';
+import Navbar from '../../components/Navbar.astro';
+import Hero from '../../components/Hero.astro';
+import Services from '../../components/Services.astro';
+import About from '../../components/About.astro';
+import Contact from '../../components/Contact.astro';
+import Footer from '../../components/Footer.astro';
+import StickyCallToAction from '../../components/StickyCallToAction.astro';
+import { useTranslations } from '../../i18n';
 
 const t = useTranslations('es');
 const brandName = "CREXATIVE";

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -11,9 +11,9 @@ import StickyCallToAction from '../components/StickyCallToAction.astro';
 const brandName = "CREXATIVE";
 
 // SEO-optimized meta data for homepage
-const pageTitle = "CREXATIVE - Premium Software Development Agency in Medellín, Colombia";
-const pageDescription = "Transform your business with custom software solutions. Expert web development, mobile apps, UI/UX design, and e-commerce solutions in Medellín, Colombia. 5+ years experience, 100+ projects delivered.";
-const pageKeywords = "software development agency, web development, mobile app development, UI UX design, custom software solutions, React development, Node.js development, e-commerce development, Medellín Colombia, software company";
+const pageTitle = "CREXATIVE - Software Development Agency in Colombia";
+const pageDescription = "Transform your business with custom software solutions. Expert web development, mobile apps, UI/UX design, and e-commerce solutions. 5+ years experience, 100+ projects delivered.";
+const pageKeywords = "software development agency, web development, mobile app development, UI UX design, custom software solutions, React development, Node.js development, e-commerce development, Colombia, software company";
 ---
 
 <Layout 


### PR DESCRIPTION
This pull request implements full internationalization (i18n) for the Crexative website, adding seamless support for both Spanish and English languages across all main pages and UI components.

Key features and changes:

- Bilingual Website: All content, navigation, forms, and UI elements now support both Spanish (default) and English. Spanish routes are at / and English at /en/.
- i18n Architecture: Introduces a robust i18n system in /src/i18n with type-safe translation keys, language utility functions, and locale files for en and es.
- Component Refactor: All major components (Navbar, Hero, Services, About, Contact, Footer, StickyCallToAction) are refactored to accept a lang prop and use the useTranslations hook for dynamic translations.
- Language Switcher: Adds a LanguageSwitcher.astro component, allowing users to toggle between languages with localStorage persistence and proper URL routing.
- SEO Optimization: Dynamic meta tags, OpenGraph locale, and structured data now reflect the active language for improved SEO and sharing.
- Dedicated Homepages: Adds /es/index.astro and /en/index.astro with language-specific SEO metadata and correct routing.
- Accessibility & UX: All forms, tooltips, buttons, and ARIA labels are internationalized for improved usability.
- Updated Documentation: CLAUDE.md and project documentation updated to detail multilingual setup, architecture, and usage.

Other improvements:

- Modernizes Footer with dynamic social links, contact info, and responsive layout.
- Refines About, Contact, and Services sections to remove hardcoded text and leverage translation keys.
- Updates Layout.astro for language-aware metadata and global styles.
- Maintains full dark/light mode support and responsive design.

This PR sets a strong foundation for future language additions and ensures a seamless multilingual experience for all visitors.